### PR TITLE
Adds support for millimetres to inches conversion

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -5,34 +5,33 @@ name: Lint and test
 
 on:
   push:
-    branches: [ master ]
+    branches: ['**']
   pull_request:
-    branches: [ master ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pipenv
-        pipenv install --dev --python ${{ matrix.python-version }} --skip-lock
-    - name: Lint with flake8
-      run: pipenv run flake8
-    - name: Lint with mypy
-      run: pipenv run mypy
-    - name: Lint with pydocstyle
-      run: pipenv run pydocstyle
-    - name: Test with pytest
-      run: pipenv run pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv install --dev --python ${{ matrix.python-version }} --skip-lock
+      - name: Lint with flake8
+        run: pipenv run flake8
+      - name: Lint with mypy
+        run: pipenv run mypy
+      - name: Lint with pydocstyle
+        run: pipenv run pydocstyle
+      - name: Test with pytest
+        run: pipenv run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-12-03
+
+A minor release adding the ability to convert from millimetres to inches and fixing
+a minor bug.
+
+### Added
+
+- The ability to convert precipitation from millimetres to inches
+
+### Fixed
+
+- A minor bug in the `Variable.convert_to` method that would cause the incorrect
+  error to be raised when trying to convert a unit that has no valid
+  conversions.
+
 ## [2.0.0] - 2024-11-25
 
 Major release. This release deprecates support for old versions of Python and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metno-locationforecast"
-version = "2.0.0"
-authors = [
-    { name = "Rory Sullivan", email = "codingrory@gmail.com" },
-]
+version = "2.1.0"
+authors = [{ name = "Rory Sullivan", email = "codingrory@gmail.com" }]
 description = "A Python interface for MET Norway's Locationforecast 2.0 service."
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = [
-    "requests>=2.25.1",
-    "tzdata>=2020.5",
-]
+dependencies = ["requests>=2.25.1", "tzdata>=2020.5"]
 license = { file = "LICENSE" }
 keywords = [
     "met",
@@ -29,7 +24,7 @@ keywords = [
     "python",
     "python3",
 ]
-classifiers=[
+classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development",
@@ -51,4 +46,4 @@ Source = "https://github.com/Rory-Sullivan/metno-locationforecast"
 Issues = "https://github.com/Rory-Sullivan/metno-locationforecast/issues"
 
 [tool.black]
-line-length=100
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 100
 
 [mypy]
 show_column_numbers = true
-files = metno_locationforecast/**/*.py
+files = src/metno_locationforecast/**/*.py
 strict = true
 
 

--- a/src/metno_locationforecast/data_containers.py
+++ b/src/metno_locationforecast/data_containers.py
@@ -62,7 +62,7 @@ class Place:
 class Variable:
     """Stores data for a weather variable.
 
-    Also has a helpfull method for converting between units.
+    Also has a helpful method for converting between units.
 
     Attributes:
         name: Name of the variable.
@@ -76,6 +76,7 @@ class Variable:
     VALID_UNIT_CONVERSIONS = {
         "m/s": {"km/h", "mph", "beaufort"},
         "celsius": {"fahrenheit"},
+        "mm": {"inches"},
     }
 
     def __init__(self, name: str, value: Union[float, int], units: str):
@@ -168,6 +169,19 @@ class Variable:
             )
             raise ValueError(msg)
 
+    def _mm_to_inches(self) -> None:
+        """Convert from millimetres to inches."""
+        if self.units == "mm":
+            self.units = "inches"
+            # There are 25.4mm in 1 inch
+            self.value = (self.value / 25.4).__round__(2)
+        else:
+            msg = (
+                "Not a valid unit conversion, expected units to be in 'mm' but instead "
+                + f"units were in {self.units}."
+            )
+            raise ValueError(msg)
+
     def convert_to(self, units: str) -> None:
         """Convert variable to given units."""
         if self.units == units:
@@ -189,6 +203,8 @@ class Variable:
             self._mps_to_mph()
         elif self.units == "m/s" and units == "beaufort":
             self._mps_to_beaufort()
+        elif self.units == "mm" and units == "inches":
+            self._mm_to_inches()
         else:
             raise ValueError("Not a valid unit conversion.")
 

--- a/src/metno_locationforecast/data_containers.py
+++ b/src/metno_locationforecast/data_containers.py
@@ -173,6 +173,9 @@ class Variable:
         if self.units == units:
             return
 
+        if self.units not in Variable.VALID_UNIT_CONVERSIONS:
+            msg = f"Not a valid unit conversion. No valid conversions for variables with units: {self.units}"  # noqa: E501
+            raise ValueError(msg)
         if units not in Variable.VALID_UNIT_CONVERSIONS[self.units]:
             msg = f"""Not a valid unit conversion. Valid destination units:
             {Variable.VALID_UNIT_CONVERSIONS[self.units]}"""

--- a/tests/test_data_containers/test_variable.py
+++ b/tests/test_data_containers/test_variable.py
@@ -168,6 +168,10 @@ class TestConvertTo:
     def ten_mps(self):
         return Variable("speed", 10, "m/s")
 
+    @pytest.fixture
+    def ninety_degrees(self):
+        return Variable("wind_from_direction", 90, "degrees")
+
     def test_no_convert(self, ten_mps):
         """Test that no conversion is made if the variable is already in the correct units."""
         ten_mps.convert_to("m/s")
@@ -199,9 +203,12 @@ class TestConvertTo:
         assert ten_mps.value == 5.0
         assert ten_mps.units == "beaufort"
 
-    def test_bad_conversion_raises_error(self, zero_celsius, ten_mps):
+    def test_bad_conversion_raises_error(self, zero_celsius, ten_mps, ninety_degrees):
         with pytest.raises(ValueError):
             zero_celsius.convert_to("kp/h")
 
         with pytest.raises(ValueError):
             ten_mps.convert_to("fahrenheit")
+
+        with pytest.raises(ValueError):
+            ninety_degrees.convert_to("cardinal_direction")

--- a/tests/test_data_containers/test_variable.py
+++ b/tests/test_data_containers/test_variable.py
@@ -157,6 +157,26 @@ def test_mps_to_beaufort():
         error._mps_to_beaufort()
 
 
+def test_mm_to_inches():
+    zero = Variable("precipitation_amount", 0, "mm")
+    little = Variable("precipitation_amount", 3, "mm")
+    lots = Variable("precipitation_amount", 15.2, "mm")
+    error = Variable("", 0, "other")
+
+    zero._mm_to_inches()
+    little._mm_to_inches()
+    lots._mm_to_inches()
+
+    assert zero.value == 0.0
+    assert little.value == 0.12
+    assert lots.value == 0.60
+
+    assert zero.units == "inches"
+
+    with pytest.raises(ValueError):
+        error._mm_to_inches()
+
+
 class TestConvertTo:
     """Tests for the convert_to(units) method."""
 
@@ -167,6 +187,10 @@ class TestConvertTo:
     @pytest.fixture
     def ten_mps(self):
         return Variable("speed", 10, "m/s")
+
+    @pytest.fixture
+    def five_mm(self):
+        return Variable("precipitation_amount", 5, "mm")
 
     @pytest.fixture
     def ninety_degrees(self):
@@ -202,6 +226,12 @@ class TestConvertTo:
 
         assert ten_mps.value == 5.0
         assert ten_mps.units == "beaufort"
+
+    def test_converting_to_inches(self, five_mm):
+        five_mm.convert_to("inches")
+
+        assert five_mm.value == 0.20
+        assert five_mm.units == "inches"
 
     def test_bad_conversion_raises_error(self, zero_celsius, ten_mps, ninety_degrees):
         with pytest.raises(ValueError):

--- a/tests/test_forecast/test_forecast_with_user_config.py
+++ b/tests/test_forecast/test_forecast_with_user_config.py
@@ -48,7 +48,7 @@ def test_forecast_with_metno_locationforecast_file(metno_locationforecast_config
 
     assert f.forecast_type == "metno_locationforecast_file"
     assert f.user_agent == "metno_locationforecast_file"
-    assert f.save_location == Path("metno_locationforecast_file")
+    assert f.save_location == Path("metno_locationforecast_file").resolve()
     assert f.base_url == "metno_locationforecast_file"
 
 


### PR DESCRIPTION
Version 2.1.0

### Adds

- The ability to convert precipitation from millimetres to inches

### Fixes

- A minor bug in the `Variable.convert_to` method that would cause the incorrect error to be raised when trying to convert a unit that has no valid conversions.
- Problems with the 'lint and test' GitHub Action.
- A problem with MyPy configuration.